### PR TITLE
#664 Crash at start of bch module: Cannot rename file//

### DIFF
--- a/src/main/java/com/mycelium/spvmodule/guava/Bip44AccountIdleService.kt
+++ b/src/main/java/com/mycelium/spvmodule/guava/Bip44AccountIdleService.kt
@@ -790,7 +790,7 @@ class Bip44AccountIdleService : AbstractScheduledService() {
                 .apply()
         configuration.maybeIncrementBestChainHeightEver(walletAccount.lastBlockSeenHeight)
 
-            saveWalletAccountToFile(walletAccount, walletFile(accountIndex))
+        saveWalletAccountToFile(walletAccount, walletFile(accountIndex))
     }
 
     fun getPrivateKeysCount(accountIndex : Int) : Int {


### PR DESCRIPTION
Synchronized files clean-up
