### PR TITLE
#682 [Unknown hostname] appears for node if custom port added

### DIFF
--- a/src/main/java/com/mycelium/spvmodule/ResolveDnsTask.kt
+++ b/src/main/java/com/mycelium/spvmodule/ResolveDnsTask.kt
@@ -2,7 +2,6 @@ package com.mycelium.spvmodule
 
 import android.os.Handler
 import android.os.Looper
-
 import java.net.InetAddress
 import java.net.UnknownHostException
 
@@ -12,7 +11,7 @@ abstract class ResolveDnsTask(private val backgroundHandler: Handler) {
     fun resolve(hostname: String) {
         backgroundHandler.post {
             try {
-                val address = InetAddress.getByName(hostname) // blocks on network
+                val address = InetAddress.getByName(removePort(hostname)) // blocks on network
 
                 callbackHandler.post { onSuccess(address) }
             } catch (x: UnknownHostException) {
@@ -20,6 +19,8 @@ abstract class ResolveDnsTask(private val backgroundHandler: Handler) {
             }
         }
     }
+
+    private fun removePort(hostname: String) = hostname.replace(Regex(":.*"), "")
 
     protected abstract fun onSuccess(address: InetAddress)
 


### PR DESCRIPTION
"The host name can either be a machine name, such as  java.sun.com, or a textual representation of its IP address. If a literal IP address is supplied, only the validity of the address format is checked."
So we need to make a valid url to resolve