### PR TITLE
fixing a regression

### DIFF
--- a/src/main/java/com/mycelium/spvmodule/SettingsFragment.kt
+++ b/src/main/java/com/mycelium/spvmodule/SettingsFragment.kt
@@ -31,6 +31,7 @@ import android.support.v7.preference.Preference
 import android.support.v7.preference.PreferenceFragmentCompat
 import android.util.Log
 import android.view.View
+import com.google.common.base.Strings
 import com.mycelium.spvmodule.guava.Bip44AccountIdleService
 import com.mycelium.spvmodule.view.HeaderPreference
 
@@ -161,7 +162,7 @@ class SettingsFragment : PreferenceFragmentCompat(), Preference.OnPreferenceChan
     private fun updateTrustedPeer() {
         val trustedPeer = config!!.trustedPeerHost
         trustedPeerPreference!!.isVisible = nodeOptionPref!!.value == "custom"
-        trustedPeerPreference!!.setSummary(trustedPeer ?: getString(R.string.preferences_trusted_peer_summary))
+        trustedPeerPreference!!.setSummary(Strings.emptyToNull(trustedPeer) ?: getString(R.string.preferences_trusted_peer_summary))
     }
 
     companion object {

--- a/src/main/java/com/mycelium/spvmodule/guava/Bip44AccountIdleService.kt
+++ b/src/main/java/com/mycelium/spvmodule/guava/Bip44AccountIdleService.kt
@@ -72,6 +72,7 @@ class Bip44AccountIdleService : AbstractScheduledService() {
     private val peerConnectivityListener: PeerConnectivityListener = PeerConnectivityListener()
     private val notificationManager = spvModuleApplication.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
     private lateinit var blockStore: BlockStore
+    // TODO: document or rename to be intuitive
     private var counterCheckImpediments: Int = 0
     private var countercheckIfDownloadIsIdling: Int = 0
     @Volatile
@@ -258,7 +259,7 @@ class Bip44AccountIdleService : AbstractScheduledService() {
 
     private fun initializePeergroup() {
         Log.d(LOG_TAG, "initializePeergroup")
-        val customPeers = (configuration.trustedPeerHost ?: "").split(",")
+        val customPeers = (configuration.trustedPeerHost).split(",")
         peerGroup = PeerGroup(Constants.NETWORK_PARAMETERS, blockChain).apply {
             setDownloadTxDependencies(0) // recursive implementation causes StackOverflowError
 


### PR DESCRIPTION
trustedPeer used `Strings.emptyToNull()` to set a default summary when null. This behavior broke recently.