### PR TITLE
#881 Allow spending unconfirmed funds for BCH->BTC exchange

### DIFF
--- a/src/main/java/com/mycelium/spvmodule/guava/Bip44AccountIdleService.kt
+++ b/src/main/java/com/mycelium/spvmodule/guava/Bip44AccountIdleService.kt
@@ -149,6 +149,7 @@ class Bip44AccountIdleService : Service() {
             val accountIndex: Int = accountIndexString.toInt()
             val walletAccount = getAccountWallet(accountIndex)
             if (walletAccount != null) {
+                walletAccount.allowSpendingUnconfirmedTransactions()
                 walletsAccountsMap[accountIndex] = walletAccount
                 if (walletAccount.lastBlockSeenHeight >= 0 && shouldInitializeCheckpoint) {
                     shouldInitializeCheckpoint = false


### PR DESCRIPTION
We need to allow spending from unconfirmed outputs to follow our btc practice