### PR TITLE
#825 Auto-uninstall all MBW modules after MBW removal

### DIFF
--- a/src/main/java/com/mycelium/spvmodule/PackageRemovedReceiver.kt
+++ b/src/main/java/com/mycelium/spvmodule/PackageRemovedReceiver.kt
@@ -14,6 +14,7 @@ class PackageRemovedReceiver : BroadcastReceiver() {
                     Intent.ACTION_PACKAGE_REMOVED -> if (!intent.getBooleanExtra(Intent.EXTRA_REPLACING, false)) {
                         val uninstallIntent = Intent(Intent.ACTION_DELETE)
                         uninstallIntent.data = Uri.parse("package:" + context.packageName)
+                        uninstallIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
                         context.startActivity(uninstallIntent)
                     }
                     Intent.ACTION_PACKAGE_REPLACED -> Runtime.getRuntime().exit(0)


### PR DESCRIPTION
Fix for
`  java.lang.RuntimeException: Unable to start receiver com.mycelium.spvmodule.PackageRemovedReceiver: android.util.AndroidRuntimeException: Calling startActivity() from outside of an Activity  context requires the FLAG_ACTIVITY_NEW_TASK flag. Is this really what you want?`