### PR TITLE
#937 kotlin.UninitializedPropertyAccessException

### DIFF
--- a/src/main/java/com/mycelium/spvmodule/SpvModuleApplication.kt
+++ b/src/main/java/com/mycelium/spvmodule/SpvModuleApplication.kt
@@ -58,6 +58,7 @@ class SpvModuleApplication : MultiDexApplication(), ModuleMessageReceiver {
         Log.i(LOG_TAG, "=== starting app using configuration: ${if (BuildConfig.IS_TESTNET) "test" else "prod"}, ${Constants.NETWORK_PARAMETERS.id}")
         super.onCreate()
 
+        blockStoreController = BlockStoreController(this)
         CommunicationManager.init(this)
         packageInfo = packageInfoFromContext(this)
 
@@ -77,7 +78,6 @@ class SpvModuleApplication : MultiDexApplication(), ModuleMessageReceiver {
         blockchainServiceCancelCoinsReceivedIntent = Intent(SpvService.ACTION_CANCEL_COINS_RECEIVED, null, this,
                 SpvService::class.java)
 
-        blockStoreController = BlockStoreController(this)
         val serviceIntent = Intent(this, Bip44AccountIdleService::class.java)
         startService(serviceIntent)
     }


### PR DESCRIPTION
moved blockstore init before pairing because instance of Bip44IdleService may be created after pairing