### PR TITLE
#930 NullPointerException at com.mycelium.wallet.modularisation.SpvBchFetcher.getSyncProgressPercents

### DIFF
--- a/src/main/java/com/mycelium/spvmodule/SpvModuleApplication.kt
+++ b/src/main/java/com/mycelium/spvmodule/SpvModuleApplication.kt
@@ -34,13 +34,15 @@ class SpvModuleApplication : MultiDexApplication(), ModuleMessageReceiver {
 
     override fun onMessage(callingPackageName: String, intent: Intent) = spvMessageReceiver.onMessage(callingPackageName, intent)
 
-    override fun onCreate() {
+    override fun attachBaseContext(base: Context?) {
         INSTANCE = if (INSTANCE != null && INSTANCE !== this) {
-            throw Error("Application was instanciated more than once?")
+            throw Error("Application was instantiated more than once?")
         } else {
             this
         }
+    }
 
+    override fun onCreate() {
         LinuxSecureRandom() // init proper random number generator
 
         StrictMode.setThreadPolicy(

--- a/src/main/java/com/mycelium/spvmodule/SpvModuleApplication.kt
+++ b/src/main/java/com/mycelium/spvmodule/SpvModuleApplication.kt
@@ -40,6 +40,7 @@ class SpvModuleApplication : MultiDexApplication(), ModuleMessageReceiver {
         } else {
             this
         }
+        super.attachBaseContext(base)
     }
 
     override fun onCreate() {


### PR DESCRIPTION
This pr is intended to quickfix a lot of crashes on prod.
By such a fix we would successfully require wallet to wait until it module would be initialized